### PR TITLE
draft: MPOperationalEvents add enumeration of all event details into fields. export as csv and as json. format for kusto ingestion

### DIFF
--- a/Convert-MpOperationalEventLogTxt.ps1
+++ b/Convert-MpOperationalEventLogTxt.ps1
@@ -78,6 +78,7 @@ function Format-EventMessage {
         # convert timestamp from g to datetime suitable for kusto ingestion
         # 6/9/2024 12:53:54 PM
         $Timestamp = [System.DateTimeOffset]::Parse($Timestamp).ToString("yyyy-MM-ddTHH:mm:ss.fffzzz")
+        #$Timestamp = [datetime]::Parse($Timestamp).ToUniversalTime().tostring("yyyy-MM-ddTHH:mm:ss.fffZ")
     }
 
     $EventMessage = $EventMessage.Remove(0, $FirstLine.Length + 1)
@@ -105,7 +106,7 @@ function Format-EventMessage {
         $DetailsName = $LineDetails[0].Trim().Replace(" ", "-")
         $DetailsValue = ""
         if ($LineDetails.Count -gt 1) {
-            $DetailsValue = $LineDetails[1].Replace("`r`n", "")
+            $DetailsValue = $LineDetails[1].Replace("`r`n", "").Trim()
         }
         if ($message.Contains($DetailsName)) {
             Write-Warning "Duplicate key: $DetailsName : $DetailsValue"

--- a/Convert-MpOperationalEventLogTxt.ps1
+++ b/Convert-MpOperationalEventLogTxt.ps1
@@ -1,4 +1,62 @@
-# Plan: Add event ID as filter in parameter.
+<#
+.SYNOPSIS
+    Convert Windows Defender MpOperationalEvents.txt to CSV or JSON
+
+.DESCRIPTION
+    This script converts the Windows Defender MpOperationalEvents.txt file to either CSV or JSON format.
+    The script reads the MpOperationalEvents.txt file and extracts the event details.
+    The output file will contain the following columns:
+    - EventTimestamp
+    - ErrorLevel
+    - EventId
+    - Machine
+    - EventDescription
+    - EventDetails (optional)
+
+    The EventDetails column will contain the event details in Tab separated or JSON format if the -expandEventDetails switch is not used.
+    If the -expandEventDetails switch is used, the EventDetails column will not be created and all event details will be created in new fields.
+
+.PARAMETER path
+    The path to the MpOperationalEvents.txt file
+    To generate the MpOperationalEvents.txt file, from an elevated command prompt, run the following command on a Windows machine with Defender Antivirus installed:
+        "C:\Program Files\Windows Defender\MpCmdRun.exe" -GetFiles
+
+.PARAMETER outFile
+    The path to the output file. The file type must be either .csv or .json
+
+.PARAMETER expandEventDetails
+    Switch to include event details in the output
+
+.EXAMPLE
+    To generate the MpOperationalEvents.txt file, from an elevated command prompt, run the following commands on a Windows machine with Defender Antivirus installed:
+    C:\temp>"C:\Program Files\Windows Defender\MpCmdRun.exe" -GetFiles
+        Launching "C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.24070.5-0\MpCmdRun.exe" -GetFiles -Reinvoke...
+        ValidateMapsConnection successfully established a connection to MAPS
+        Collecting events from Operational Event Log...
+        ...
+        Creating CAB file...
+        Files successfully created in C:\ProgramData\Microsoft\Windows Defender\Support\MpSupportFiles.cab
+
+    C:\temp>copy C:\ProgramData\Microsoft\Windows Defender\Support\MpSupportFiles.cab C:\temp
+        1 file(s) copied.
+    C:\temp>md C:\temp\MpSupportFiles
+    C:\temp>expand -R -I "C:\temp\MpSupportFiles.cab" -F:* "c:\temp\MpSupportFiles"
+
+.EXAMPLE
+    Convert-MpOperationalEventLogTxt -path "C:\temp\MpOperationalEvents.txt" -outFile "C:\temp\MpOperationalEvents.csv"
+    Convert the MpOperationalEvents.txt file to a CSV file
+
+.EXAMPLE
+    Convert-MpOperationalEventLogTxt -path "C:\temp\MpOperationalEvents.txt" -outFile "C:\temp\MpOperationalEvents.json"
+    Convert the MpOperationalEvents.txt file to a JSON file
+
+.EXAMPLE
+    Convert-MpOperationalEventLogTxt -path "C:\temp\MpOperationalEvents.txt" -outFile "C:\temp\MpOperationalEvents.csv" -expandEventDetails
+    Convert the MpOperationalEvents.txt file to a CSV file with expanded event details into a separate columns
+
+.LINK
+    https://github.com/typicaldao/Defender-Toolbox/blob/main/Convert-MpOperationalEventLogTxt.ps1
+#>
 
 function Convert-MpOperationalEventLogTxt(
     [string]$path = "$PWD\MpOperationalEvents.txt",

--- a/Convert-MpOperationalEventLogTxt.ps1
+++ b/Convert-MpOperationalEventLogTxt.ps1
@@ -2,8 +2,9 @@
 
 function Convert-MpOperationalEventLogTxt {
     param(
-        [string]$Path="$PWD\MpOperationalEvents.txt",
-        [string]$OutFile="$PWD\MpOperationalEvents.csv"
+        [string]$Path = "$PWD\MpOperationalEvents.txt",
+        [string]$OutFile = "$PWD\MpOperationalEvents.csv",
+        [switch]$asCsv
     )
     
     if ((Test-Path $Path) -eq $false ) {
@@ -12,49 +13,127 @@ function Convert-MpOperationalEventLogTxt {
     }
     
     #Read Data
-    $LogData = (Get-Content -Path $Path) + "*****"
+    $EventSeparator = "*****"
+    $LogData = (Get-Content -Path $Path) + $EventSeparator
     
     # Some variables
-    $Counter = -1
-    $Details = ""
-    $Result = [array][PSCustomObject]@() 
-    $Description = ""
-    
+    $Result = [collections.arraylist]::new()
     $i = 0 # Counter for Write-Progress
     $TotalLines = $Logdata.Count
-    
-    $LogData | ForEach-Object {
-        if ($_ -match '^[*]+') {
-            if ($Counter -ne -1) {
-               $Result += [PSCustomObject]@{
-                Time = $Timestamp
-                ErrorLevel = $Level
-                EventId = $Id
-                EventDescription = $Description
-                EventDetails = $Details
-               }
-            }
-            # Initialization of event block
-            $Details = ""
-            $Counter = 0 
-        } 
-        # Parse the first line of event info
-        if ($Counter -eq 1) {  
-            $Timestamp = $_.Substring(0,22) 
-            $Level, $Id = $_.Split()[5], $_.Split()[8] 
-        } 
-        # One-line description
-        elseif ($Counter -eq 2) {
-            $Description = $_
-        }
-        # Multi-lines details
-        elseif ($Counter -gt 2) {
-            $Details += $_ + "`n"
-        }
-        $Counter++ 
+    $Header = @{}
+    $EventMessage = [text.stringbuilder]::new()
+
+    foreach ($Line in $LogData) {
         $i++
-        Write-Progress -Activity "Parsing" -Status "$i of $TotalLines lines parsed" -PercentComplete ($i/($TotalLines)*100)
+        Write-Progress -Activity "Parsing" -Status "$i of $TotalLines lines parsed" -PercentComplete ($i / ($TotalLines) * 100)
+
+        if ($Line.Length -lt 1) {
+            continue
+        }
+        if ($Line.StartsWith($EventSeparator)) {
+            [void]$Result.Add((Format-EventMessage $EventMessage $Header))
+            [void]$EventMessage.Clear()
+            continue
+        }
+
+        [void]$EventMessage.AppendLine($Line)
     }
-    
-    $Result | Export-Csv -Encoding utf8BOM -Path $OutFile
+
+    [void]$Result.Insert(0, (Format-Headers $Header))
+    $JsonFile = convertto-json $Result -Depth 10
+    if ($asCsv) {
+        $Result | Export-Csv -Encoding utf8BOM -NoTypeInformation -Path $OutFile
+    }
+    else {
+        $JsonFile | Out-File -Encoding utf8BOM -FilePath $OutFile
+    }
+}
+
+function Format-EventMessage {
+    param(
+        [text.stringbuilder]$EventMessage,
+        [hashtable]$FieldList
+    )
+    $FirstLine = $EventMessage.ToString().Split("`n")[0]
+    $FirstLinePattern = "(?<Timestamp>.+?)`t(?<Provider>.+?)`t(?<Level>.+?)`t`t`t(?<Id>.+?)`t(?<Machine>.+?)`r"
+    $FirstLineMatch = [regex]::Match($FirstLine, $FirstLinePattern)
+    if ($FirstLineMatch.Success -eq $false) {
+        write-warning "bad first line: $FirstLine"
+        $Timestamp = "unknown"
+        $Level = "unknown"
+        $Id = "unknown"
+        $Machine = "unknown"
+    }
+    else {
+        $Timestamp = $FirstLineMatch.Groups["Timestamp"].Value
+        $Level = $FirstLineMatch.Groups["Level"].Value
+        $Id = $FirstLineMatch.Groups["Id"].Value
+        $Machine = $FirstLineMatch.Groups["Machine"].Value
+        # convert timestamp from g to datetime suitable for kusto ingestion
+        # 6/9/2024 12:53:54 PM
+        $Timestamp = [datetime]::Parse($Timestamp).ToUniversalTime().tostring("yyyy-MM-ddTHH:mm:ss.fffZ")
+    }
+
+    $EventMessage = $EventMessage.Remove(0, $FirstLine.Length + 1)
+    $tabArray = $EventMessage.ToString().Split("`t")
+    if ($tabArray.Count -lt 1) {
+        write-warning "bad event: $EventMessage"
+        return
+    }
+
+    $Description = $tabArray[0]
+    $message = [ordered]@{
+        EventTimestamp   = $Timestamp
+        ErrorLevel       = $Level
+        EventId          = $Id
+        Machine          = $Machine
+        EventDescription = $Description
+    }
+
+    for ($i = 1; $i -lt $tabArray.Count; $i++) {
+        $LineDetails = $tabArray[$i].split(":", 2)
+        if ($LineDetails.Count -lt 1) {
+            write-warning "bad details: $tabArray[$i]"
+            continue
+        }
+        $DetailsName = $LineDetails[0].Trim().replace(" ", "-")
+        $DetailsValue = ""
+        if ($LineDetails.Count -gt 1) {
+            $DetailsValue = $LineDetails[1].Trim()
+        }
+        if ($message.Contains($DetailsName)) {
+            Write-Warning "Duplicate key: $DetailsName : $DetailsValue"
+        }
+        else {
+            [void]$message.Add($DetailsName, $DetailsValue)
+        }
+        if ($FieldList.Contains($DetailsName) -eq $false) {
+            [void]$FieldList.Add($DetailsName, $DetailsName)
+        }
+    }
+    return $message
+}
+
+function Format-Headers {
+    param(
+        [hashtable]$HeaderDictionary
+    )
+
+    $Header = [ordered]@{
+        EventTimestamp   = "Timestamp"
+        ErrorLevel       = "Level"
+        EventId          = "Id"
+        Machine          = "Machine"
+        EventDescription = "Description"
+    }
+
+    foreach ($kvp in $HeaderDictionary.GetEnumerator() | Sort-Object Name) {
+        if ($Header.Contains($kvp.name)) {
+            Write-Warning "Duplicate key: $kvp.name : $kvp.value"
+        }
+        else {
+            [void]$Header.Add($kvp.name, $kvp.value)
+        }
+    }
+    return $Header
 }


### PR DESCRIPTION
draft: MPOperationalEvents 
add enumeration of all event details into fields. 
export as csv and as json. 
format time for kusto ingestion
 
current export is inconsistent and does not enumerate all fields
pr:
make it work with all messages consistently
optionally make it searchable 

source log:
![image](https://github.com/user-attachments/assets/2e17dbe0-e3c9-4650-9210-67054a287336)

current version of csv output:
![image](https://github.com/user-attachments/assets/1ffe4a5f-e7cc-4edf-a308-d890114fa085)

cleaned up csv to ensure single line, make fields of all available event details, convert time to utc with offset, optionally export as json. 
can also ingest into kusto:

![image](https://github.com/user-attachments/assets/cbbc4e46-cbad-4222-95a2-df55cb81cb13)

 
in json a first record that gets used as a header using ordered hashtable.
columns are set in order so both csv export and json ingest into kusto gets the columns correct
 
![image](https://github.com/user-attachments/assets/518c5864-c598-4b2a-9110-27b9a4801a36)

![image](https://github.com/user-attachments/assets/c732c3d5-3e16-4ab5-94bc-189a02e564c5)

